### PR TITLE
Improve ipa-bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority
+# mongodb+srv://<username>:<password>@<cluster-address>?w=majority
 MONGODB_URL=""
 
 # An account with 2f enabled to download ipas

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Please make sure to provide valid App Store URLs when using the `/request` and `
 Note: The bot can only process one app download or deletion request at a time. If there is already an ongoing request, additional requests will be added to a queue and processed in order once the previous request is completed.
 
 ## Running into errors while requesting an app?
-There may be some other packages that you need to manually install. In order to see the error message, you can run the bash script that you see in your Terminal upon requesting an app. It should look something like this:
+You will need to install MongoSH if you haven't already. You can follow their tutorial here: https://www.mongodb.com/docs/mongodb-shell/install
+
+There may also be some other packages that you need to manually install. In order to see a detailed error message, you can run the bash script that you see in your Terminal upon requesting an app. It should look something like this:
 ```shell
 bash ./src/bash-decryptor/download-ipa.sh 1137397744 us 0123456789 ''
 ```

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ To run this bot, make sure you have the following software installed:
    ```shell
    yarn install
    ```
+   a. You'll need to install mongosh manually by visiting their page and following their instructions: https://www.mongodb.com/docs/mongodb-shell/install
 
-4. Rename the `.env.example` file to `.env`:
+5. Rename the `.env.example` file to `.env`:
 
    ```shell
    mv .env.example .env
    ```
 
-5. Open the `.env` file and provide the necessary values for the environment variables.
+6. Open the `.env` file and provide the necessary values for the environment variables.
 
 ## Usage
 
@@ -64,6 +65,13 @@ The following commands are available for interacting with the IPA Bot:
 Please make sure to provide valid App Store URLs when using the `/request` and `/delete` commands.
 
 Note: The bot can only process one app download or deletion request at a time. If there is already an ongoing request, additional requests will be added to a queue and processed in order once the previous request is completed.
+
+## Running into errors while requesting an app?
+There may be some other packages that you need to manually install. In order to see the error message, you can run the bash script that you see in your Terminal upon requesting an app. It should look something like this:
+```shell
+bash ./src/bash-decryptor/download-ipa.sh 1137397744 0123456789 ''
+```
+From here, you'll recieve an error message indicating what the issue is.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Note: The bot can only process one app download or deletion request at a time. I
 ## Running into errors while requesting an app?
 There may be some other packages that you need to manually install. In order to see the error message, you can run the bash script that you see in your Terminal upon requesting an app. It should look something like this:
 ```shell
-bash ./src/bash-decryptor/download-ipa.sh 1137397744 0123456789 ''
+bash ./src/bash-decryptor/download-ipa.sh 1137397744 us 0123456789 ''
 ```
 From here, you'll recieve an error message indicating what the issue is.
 

--- a/src/bash-decryptor/lib/app_utils.sh
+++ b/src/bash-decryptor/lib/app_utils.sh
@@ -2,12 +2,13 @@
 
 get_app_info_by_id() {
   local trackId=$1
+  local countryCode=$2
   local response
   local error_message
   local exists
 
   # Make the search request
-  local search_url="https://itunes.apple.com/lookup?id=$trackId&cacheBust=$(date +%s)"
+  local search_url="https://itunes.apple.com/lookup?id=$trackId&country=$countryCode&cacheBust=$(date +%s)"
   response=$(curl -s "$search_url")
 
   # Check for errors in the response

--- a/src/bash-decryptor/lib/env_loader.sh
+++ b/src/bash-decryptor/lib/env_loader.sh
@@ -46,9 +46,18 @@ if [[ -z "$ITUNES_PASS" || -z "$ITUNES_USER" ]]; then
 fi
 
 # Set paths
-ipatool="src/bash-decryptor/bin/ipatool-2.1.3-linux-arm64"
 if [[ "$OSTYPE" == "darwin"* ]]; then
   ipatool="src/bash-decryptor/bin/ipatool-2.1.3-macos-arm64"
+else
+  arch=$(uname -m)
+  if [[ "$arch" == "x86_64" ]]; then
+    ipatool="src/bash-decryptor/bin/ipatool-2.1.3-linux-amd64"
+  elif [[ "$arch" == "aarch64" ]]; then
+    ipatool="src/bash-decryptor/bin/ipatool-2.1.3-linux-arm64"
+  else
+    echo "Your architecture ($arch) is not supported."
+    exit 1
+  fi
 fi
 chmod +x "$ipatool"
 

--- a/src/tg-bot/bot.ts
+++ b/src/tg-bot/bot.ts
@@ -116,7 +116,7 @@ async function handleRequest(event: NewMessageEvent) {
   }
 
   const urlParts = message.text.trim().split(" ");
-  if (urlParts.length < 2 || !message.text.includes("apps.apple.com")) {
+  if (urlParts.length < 2 || !/apps\.apple\.com|itunes\.apple\.com/.test(message.text)) {
     await client.sendMessage(sendTo, {
       message: "❌ Invalid App Store URL.",
       replyTo: message,
@@ -126,9 +126,15 @@ async function handleRequest(event: NewMessageEvent) {
   }
 
   const url = urlParts[1].trim();
+
   const idRegex = /\/id(\d+)/;
-  const match = url.match(idRegex);
-  const trackId = match ? match[1] : null;
+  const countryRegex = /apple\.com\/(\w\w)\//;
+
+  const countryId = url.match(idRegex);
+  const matchCountry = url.match(countryRegex);
+
+  const trackId = countryId ? countryId[1] : "";
+  const countryCode = matchCountry ? matchCountry[1] : "us";
 
   if (!(trackId && trackId.length && trackId.length < 15)) {
     await client.sendMessage(sendTo, {
@@ -190,7 +196,7 @@ async function handleRequest(event: NewMessageEvent) {
   try {
     if (!appInfo) {
       console.log("No app found for trackId:", trackId);
-      await startDecryption({ message, trackId, sendTo });
+      await startDecryption({ message, trackId, countryCode, sendTo });
 
       // Lookup the app we just decrypted by trackId
       appInfo = (await collection.findOne(

--- a/src/tg-bot/startDecryption.ts
+++ b/src/tg-bot/startDecryption.ts
@@ -7,10 +7,12 @@ import { stringContainsArray } from "./stringContainsArray";
 export async function startDecryption({
   message,
   trackId,
+  countryCode,
   sendTo,
 }: {
   message: Api.Message;
   trackId: string;
+  countryCode: string;
   sendTo: string;
 }) {
   let output = "";
@@ -25,6 +27,7 @@ export async function startDecryption({
     const yarnProcess = spawn("yarn", [
       "up",
       trackId,
+      countryCode,
       sendTo,
       `${message.replyToMsgId || ""}`,
     ]);


### PR DESCRIPTION
- add region grabbing from app store url (defaults to US)
  - this will be used for the automatic region changing to allow for apps in different regions to be downloaded and decrypted
  - **soon**™️ (some time in the future, not sure yet)
- add proper support for paid apps; apps that you have paid for can be decrypted, while apps you haven't paid for will return an error
- database entries now expire after 1 day. this does a couple things:
  - it allows for the database to be updated with new apps
  - it'll help reduce the size of the database, albeit it wasn't that big to begin with
    - don't want it to be 1 day? it can be changed here:
      https://github.com/Geczy/ipa-bot/blob/016de9cf0107a9295b6c098d580c4ed967bc14cd/src/bash-decryptor/download-ipa.sh#L66-L67
- add proper platform detection for ipatool & added amd64 binary
- added support for itunes.apple.com urls
- updated readme to let the user know that some packages may need to be installed manually:
https://github.com/Geczy/ipa-bot/blob/016de9cf0107a9295b6c098d580c4ed967bc14cd/README.md#L69-L76